### PR TITLE
[week-1/home-work] 무무

### DIFF
--- a/zz.home-work/src/App.test.tsx
+++ b/zz.home-work/src/App.test.tsx
@@ -1,3 +1,23 @@
-describe('Todo List', () => {
-  test('-', () => {});
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from './App';
+
+describe('Todo 통합 테스트', () => {
+  it('할 일을 추가하고, 체크박스를 클릭하면 텍스트에 취소선이 그어진다', () => {
+    render(<App />);
+    const todoInput = screen.getByLabelText('New Todo');
+    const dateInput = screen.getByLabelText('Deadline');
+    const addButton = screen.getByRole('button', { name: /Add Todo/i });
+
+    fireEvent.change(todoInput, { target: { value: '통합테스트 할 일' } });
+    fireEvent.change(dateInput, { target: { value: '2024-07-01' } });
+    fireEvent.click(addButton);
+
+    const todoText = screen.getByText('통합테스트 할 일');
+    expect(todoText).toBeInTheDocument();
+
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    expect(todoText.parentElement).toHaveStyle('text-decoration: line-through');
+  });
 });

--- a/zz.home-work/src/components/TodoForm.test.tsx
+++ b/zz.home-work/src/components/TodoForm.test.tsx
@@ -1,0 +1,26 @@
+// src/components/TodoForm.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TodoForm } from './todo-form';
+import { vi } from 'vitest';
+import { Todo } from '../types/todo';
+
+describe('TodoForm 단위 테스트', () => {
+  const mockSetTodos = vi.fn();
+  const todos: Todo[] = [];
+
+  beforeEach(() => {
+    mockSetTodos.mockClear();
+  });
+
+  it('할 일 텍스트와 데드라인 날짜를 입력받을 수 있다', () => {
+    render(<TodoForm todos={todos} setTodos={mockSetTodos} />);
+    const todoInput = screen.getByLabelText('New Todo');
+    const dateInput = screen.getByLabelText('Deadline');
+
+    fireEvent.change(todoInput, { target: { value: '테스트 할 일' } });
+    fireEvent.change(dateInput, { target: { value: '2024-07-01' } });
+
+    expect(todoInput).toHaveValue('테스트 할 일');
+    expect(dateInput).toHaveValue('2024-07-01');
+  });
+});

--- a/zz.home-work/src/components/__tests__/todo-form.test.tsx
+++ b/zz.home-work/src/components/__tests__/todo-form.test.tsx
@@ -1,8 +1,8 @@
 // src/components/TodoForm.test.tsx
 import { render, screen, fireEvent } from '@testing-library/react';
-import { TodoForm } from './todo-form';
+import { TodoForm } from '../todo-form';
 import { vi } from 'vitest';
-import { Todo } from '../types/todo';
+import { Todo } from '../../types/todo';
 
 describe('TodoForm 단위 테스트', () => {
   const mockSetTodos = vi.fn();


### PR DESCRIPTION
# 구현 내용
- 단위 테스트: TodoForm 컴포넌트에서 할 일 텍스트와 데드라인 날짜를 정상적으로 입력받을 수 있는지 테스트를 추가했습니다.
- 통합 테스트: 실제 앱에서 할 일을 추가하고, 체크박스를 클릭하면 해당 할 일 텍스트에 취소선이 적용되는지 검증하는 테스트를 추가했습니다.

# 고민되었던 부분
TodoList 컴포넌트는 입력 기능이 없고, 오직 리스트만 렌더링하기 때문에, 할 일 추가/입력 테스트는 TodoForm에서만 진행해야 했습니다.
체크박스 클릭 시 취소선 스타일이 실제로 어떤 DOM 요소에 적용되는지 확인하는 부분이 고민되었습니다.

# 테스트를 실행하는 방법
```bash
npm install
npm run test
```