### PR TITLE
[week-2/home-work] 무무

### DIFF
--- a/zz.home-work/src/App.test.tsx
+++ b/zz.home-work/src/App.test.tsx
@@ -8,8 +8,14 @@ describe('Todo 통합 테스트', () => {
     const dateInput = screen.getByLabelText('Deadline');
     const addButton = screen.getByRole('button', { name: /Add Todo/i });
 
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const dd = String(today.getDate()).padStart(2, '0');
+    const todayStr = `${yyyy}-${mm}-${dd}`;
+    fireEvent.change(dateInput, { target: { value: todayStr } });
+
     fireEvent.change(todoInput, { target: { value: '통합테스트 할 일' } });
-    fireEvent.change(dateInput, { target: { value: '2024-07-01' } });
     fireEvent.click(addButton);
 
     const todoText = screen.getByText('통합테스트 할 일');

--- a/zz.home-work/src/App.test.tsx
+++ b/zz.home-work/src/App.test.tsx
@@ -1,3 +1,23 @@
-describe('Todo List', () => {
-  test('-', () => {});
+import { render, screen, fireEvent } from '@testing-library/react';
+import App from './App';
+
+describe('Todo 통합 테스트', () => {
+  it('할 일을 추가하고, 체크박스를 클릭하면 텍스트에 취소선이 그어진다', () => {
+    render(<App />);
+    const todoInput = screen.getByLabelText('New Todo');
+    const dateInput = screen.getByLabelText('Deadline');
+    const addButton = screen.getByRole('button', { name: /Add Todo/i });
+
+    fireEvent.change(todoInput, { target: { value: '통합테스트 할 일' } });
+    fireEvent.change(dateInput, { target: { value: '2024-07-01' } });
+    fireEvent.click(addButton);
+
+    const todoText = screen.getByText('통합테스트 할 일');
+    expect(todoText).toBeInTheDocument();
+
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    expect(todoText.parentElement).toHaveStyle('text-decoration: line-through');
+  });
 });

--- a/zz.home-work/src/components/TodoForm.test.tsx
+++ b/zz.home-work/src/components/TodoForm.test.tsx
@@ -1,0 +1,26 @@
+// src/components/TodoForm.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TodoForm } from './todo-form';
+import { vi } from 'vitest';
+import { Todo } from '../types/todo';
+
+describe('TodoForm 단위 테스트', () => {
+  const mockSetTodos = vi.fn();
+  const todos: Todo[] = [];
+
+  beforeEach(() => {
+    mockSetTodos.mockClear();
+  });
+
+  it('할 일 텍스트와 데드라인 날짜를 입력받을 수 있다', () => {
+    render(<TodoForm todos={todos} setTodos={mockSetTodos} />);
+    const todoInput = screen.getByLabelText('New Todo');
+    const dateInput = screen.getByLabelText('Deadline');
+
+    fireEvent.change(todoInput, { target: { value: '테스트 할 일' } });
+    fireEvent.change(dateInput, { target: { value: '2024-07-01' } });
+
+    expect(todoInput).toHaveValue('테스트 할 일');
+    expect(dateInput).toHaveValue('2024-07-01');
+  });
+});

--- a/zz.home-work/src/components/__tests__/todo-form.test.tsx
+++ b/zz.home-work/src/components/__tests__/todo-form.test.tsx
@@ -1,8 +1,8 @@
 // src/components/TodoForm.test.tsx
 import { render, screen, fireEvent } from '@testing-library/react';
-import { TodoForm } from './todo-form';
+import { TodoForm } from '../todo-form';
 import { vi } from 'vitest';
-import { Todo } from '../types/todo';
+import { Todo } from '../../types/todo';
 
 describe('TodoForm 단위 테스트', () => {
   const mockSetTodos = vi.fn();

--- a/zz.home-work/src/components/__tests__/todo-form.test.tsx
+++ b/zz.home-work/src/components/__tests__/todo-form.test.tsx
@@ -24,3 +24,39 @@ describe('TodoForm 단위 테스트', () => {
     expect(dateInput).toHaveValue('2024-07-01');
   });
 });
+
+describe('TodoForm', () => {
+  const setup = () => {
+    const setTodos = vi.fn();
+    render(<TodoForm todos={[]} setTodos={setTodos} />);
+    return { setTodos };
+  };
+
+  it('100자 이상의 할일을 입력하면 추가 버튼이 비활성화된다', () => {
+    setup();
+    const input = screen.getByLabelText(/New Todo/i);
+    const longText = 'a'.repeat(100);
+    fireEvent.change(input, { target: { value: longText } });
+    const button = screen.getByRole('button', { name: /Add Todo/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('데드라인이 오늘 날짜 미만이면 추가 버튼이 비활성화된다', () => {
+    setup();
+    const input = screen.getByLabelText(/New Todo/i);
+    const deadlineInput = screen.getByLabelText(/Deadline/i);
+
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yyyy = yesterday.getFullYear();
+    const mm = String(yesterday.getMonth() + 1).padStart(2, '0');
+    const dd = String(yesterday.getDate()).padStart(2, '0');
+    const yesterdayStr = `${yyyy}-${mm}-${dd}`;
+
+    fireEvent.change(input, { target: { value: '테스트 할일' } });
+    fireEvent.change(deadlineInput, { target: { value: yesterdayStr } });
+
+    const button = screen.getByRole('button', { name: /Add Todo/i });
+    expect(button).toBeDisabled();
+  });
+});

--- a/zz.home-work/src/components/todo-form.tsx
+++ b/zz.home-work/src/components/todo-form.tsx
@@ -13,8 +13,24 @@ export const TodoForm = ({
   const { initForm, updateDeadline, updateTodo, todo, deadline } =
     useTodoForm();
 
+  const getTodayString = () => {
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const dd = String(today.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+  };
+
+  const isTodoTooLong = todo.length >= 100;
+  const isDeadlineInvalid = !!deadline && deadline < getTodayString();
+  const isAddDisabled =
+    !todo.trim() ||
+    !deadline ||
+    isTodoTooLong ||
+    isDeadlineInvalid;
+
   const handleAddTodo = () => {
-    if (!(todo.trim() && deadline)) return;
+    if (isAddDisabled) return;
 
     setTodos([
       ...todos,
@@ -35,8 +51,13 @@ export const TodoForm = ({
         variant="outlined"
         fullWidth
         value={todo}
-        onChange={(e) => updateTodo(e.target.value)}
+        onChange={(e) => {
+          if (e.target.value.length <= 99) {
+            updateTodo(e.target.value);
+          }
+        }}
         style={{ marginBottom: '1rem' }}
+        slotProps={{ htmlInput: { maxLength: 100 } }}
       />
       <TextField
         label="Deadline"
@@ -49,13 +70,14 @@ export const TodoForm = ({
           updateDeadline(selectedDate);
         }}
         style={{ marginBottom: '1rem' }}
+        slotProps={{ htmlInput: { min: getTodayString() } }}
       />
       <Button
         variant="contained"
         color="primary"
         onClick={handleAddTodo}
         fullWidth
-        disabled={!todo.trim() || !deadline}
+        disabled={isAddDisabled}
       >
         Add Todo
       </Button>


### PR DESCRIPTION
# 구현 내용
- 신규 기능 구현
  - 할 일 입력란에 100자 이상 입력 시 추가 버튼이 비활성화됩니다.
  - 데드라인이 오늘 날짜보다 이전이면 추가 버튼이 비활성화됩니다.
- 테스트 코드 작성
  - 테스트에서 날짜 입력 시, 항상 오늘 날짜 이상이 되도록 동적으로 날짜를 생성해서 사용했습니다.

# 고민되었던 부분
- 처음에는 날짜를 하드코딩해서 테스트가 실패하는 문제가 있었습니다. 실제 날짜와 비교하는 로직이 있다면, 테스트에서도 동적으로 날짜를 만들어야 한다는 점을 배웠습니다.
- 기존에는 inputProps를 바로 썼는데, 경고가 떠서 slotProps로 변경했습니다. MUI 컴포넌트의 props 구조가 바뀌는 경우가 많으니, 공식 문서를 꼭 확인해야겠다고 느꼈습니다.
- 입력값의 유효성을 어디서 어떻게 막을지 고민했습니다. 입력 자체를 막는 것과, 버튼을 비활성화하는 것의 UX 차이도 생각해보게 되었습니다.