### PR TITLE
[Week2/home work] 심영찬

### DIFF
--- a/zz.home-work/src/components/test/todo-list.validation.test.tsx
+++ b/zz.home-work/src/components/test/todo-list.validation.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import {TodoList} from '../todo-list'
+import '@testing-library/jest-dom'
+
+describe('TodoList 신규 기능 유효성 테스트', () => {
+  it('할 일 입력 시 100자 초과이면 에러 메시지 노출', () => {
+    const longText = 'a'.repeat(101)
+    render(<TodoList todos={[{ id: 1, text: longText, completed: false, deadline: '2025-01-01' }]} setTodos={vi.fn()} />)
+    expect(screen.getByText(/100자 이하로 입력하세요/i)).toBeInTheDocument()
+  })
+
+  it('할 일 입력 시 데드라인이 오늘 이전이면 에러 메시지 노출', () => {
+    const today = new Date().toISOString().slice(0, 10)        
+    const yesterday = new Date(Date.now() - 86400 * 1000).toISOString().slice(0, 10)
+    render(
+      <TodoList
+        todos={[{ id: 2, text: '테스트', completed: false, deadline: yesterday }]}
+        setTodos={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/오늘 날짜 이후로 선택하세요/i)).toBeInTheDocument()
+  })
+})

--- a/zz.home-work/src/components/todo-list.tsx
+++ b/zz.home-work/src/components/todo-list.tsx
@@ -4,6 +4,8 @@ import {
   Checkbox,
   ListItemText,
   IconButton,
+  Typography,
+  Box,
 } from '@mui/material';
 import { parseISO, format } from 'date-fns';
 import { Todo } from '../types/todo';
@@ -17,6 +19,17 @@ export const TodoList = ({
   todos: Todo[];
   setTodos: Dispatch<React.SetStateAction<Todo[]>>;
 }) => {
+  // 오늘 날짜(YYYY-MM-DD) 문자열
+  const todayStr = new Date().toISOString().slice(0, 10);
+
+  // 유효성 판단 함수
+  const isTooLong   = (t: Todo) => t.text.length > 100;
+  const isPastDate  = (t: Todo) => t.deadline < todayStr;
+
+  // 에러 존재 여부
+  const hasLongTodo = todos.some(isTooLong);
+  const hasPastTodo = todos.some(isPastDate);
+
   const handleToggleTodo = (id: number) => {
     setTodos(updateToggle(todos, id));
   };
@@ -26,32 +39,47 @@ export const TodoList = ({
   };
 
   return (
-    <List style={{ marginTop: '2rem' }}>
-      {todos.map((todo) => (
-        <ListItem key={todo.id}>
-          <Checkbox
-            checked={todo.completed}
-            onChange={() => handleToggleTodo(todo.id)}
-          />
-          <ListItemText
-            primary={todo.text}
-            secondary={`Deadline: ${format(
-              parseISO(todo.deadline),
-              'yyyy-MM-dd'
-            )}`}
-            style={{
-              textDecoration: todo.completed ? 'line-through' : 'none',
-            }}
-          />
-          <IconButton
-            edge="end"
-            aria-label="delete"
-            onClick={() => handleDeleteTodo(todo.id)}
-          >
-            🗑️
-          </IconButton>
-        </ListItem>
-      ))}
-    </List>
+    <Box>
+      {/* --- 에러 메시지 렌더링 ------------------------------------- */}
+      {hasLongTodo && (
+        <Typography color="error" sx={{ mb: 1 }}>
+          할 일은 100자 이하로 입력하세요
+        </Typography>
+      )}
+      {hasPastTodo && (
+        <Typography color="error" sx={{ mb: 1 }}>
+          오늘 날짜 이후로 선택하세요
+        </Typography>
+      )}
+
+      {/* --- 실제 Todo 리스트 ------------------------------------- */}
+      <List sx={{ mt: 1 }}>
+        {todos.map((todo) => (
+          <ListItem key={todo.id}>
+            <Checkbox
+              checked={todo.completed}
+              onChange={() => handleToggleTodo(todo.id)}
+            />
+            <ListItemText
+              primary={todo.text}
+              secondary={`Deadline: ${format(
+                parseISO(todo.deadline),
+                'yyyy-MM-dd'
+              )}`}
+              sx={{
+                textDecoration: todo.completed ? 'line-through' : 'none',
+              }}
+            />
+            <IconButton
+              edge="end"
+              aria-label="delete"
+              onClick={() => handleDeleteTodo(todo.id)}
+            >
+              🗑️
+            </IconButton>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
   );
 };


### PR DESCRIPTION
## 구현 내용
- **TodoForm**
  - 할 일 입력 글자 수가 100자를 초과하면 에러 메시지 렌더 & `Add` 버튼 비활성화
  - 데드라인이 오늘 날짜보다 과거일 경우 에러 메시지 렌더 & `Add` 버튼 비활성화
- **TodoList**
  - 위 조건을 만족하지 못하는 Todo 항목을 렌더링할 때도 동일한 에러 메시지를 노출
- **테스트 코드**
  - `todo-list.validation.test.tsx`  
    - 100자 초과 텍스트 입력 시 오류 문구가 화면에 표시되는지 확인  
    - 과거 날짜 데드라인 입력 시 오류 문구가 화면에 표시되는지 확인  
  - 기존 단위·스냅샷 테스트는 모두 **pass**

## 궁금한 점
1. MUI `TextField` helperText 내부에서 error 스타일을 통일하려면 보통 어떤 패턴을 쓰는지 궁금합니다.
2. 날짜 비교를 `new Date()` 기준으로 매번 계산했는데, 테스트 안정성을 위해 더 깔끔한 방법이 있을지 궁금합니다.